### PR TITLE
SN-315: feat: Added permissions to hide the filters from dashboard li…

### DIFF
--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -61,6 +61,7 @@ import CertifiedBadge from 'src/components/CertifiedBadge';
 import { loadTags } from 'src/components/Tags/utils';
 import DashboardCard from 'src/features/dashboards/DashboardCard';
 import { DashboardStatus } from 'src/features/dashboards/types';
+import { userHasPermission } from 'src/dashboard/util/permissionUtils';
 
 const PAGE_SIZE = 25;
 const PASSWORDS_NEEDED_MESSAGE = t(
@@ -500,6 +501,31 @@ function DashboardList(props: DashboardListProps) {
   );
 
   const filters: Filters = useMemo(() => {
+    const canSeeOwnerFilter = userHasPermission(
+      props.user,
+      'Dashboard',
+      'can_show_owner_filter',
+    );
+    const canSeeCreatedByFilter = userHasPermission(
+      props.user,
+      'Dashboard',
+      'can_show_created_by_filter',
+    );
+    const canSeeFavoriteFilter = userHasPermission(
+      props.user,
+      'Dashboard',
+      'can_show_favorite_filter',
+    );
+    const canSeePublishedFilter = userHasPermission(
+      props.user,
+      'Dashboard',
+      'can_show_published_filter',
+    );
+    const canSeeCertifiedFilter = userHasPermission(
+      props.user,
+      'Dashboard',
+      'can_see_certified_filter',
+    );
     const filters_list = [
       {
         Header: t('Search'),
@@ -508,7 +534,9 @@ function DashboardList(props: DashboardListProps) {
         input: 'search',
         operator: FilterOperator.titleOrSlug,
       },
-      {
+    ] as Filters;
+    if (canSeeOwnerFilter) {
+      filters_list.push({
         Header: t('Owner'),
         key: 'owner',
         id: 'owners',
@@ -529,8 +557,10 @@ function DashboardList(props: DashboardListProps) {
           props.user,
         ),
         paginate: true,
-      },
-      {
+      });
+    }
+    if (canSeeCreatedByFilter) {
+      filters_list.push({
         Header: t('Created by'),
         key: 'created_by',
         id: 'created_by',
@@ -551,8 +581,11 @@ function DashboardList(props: DashboardListProps) {
           props.user,
         ),
         paginate: true,
-      },
-      {
+      });
+    }
+
+    if (canSeePublishedFilter) {
+      filters_list.push({
         Header: t('Status'),
         key: 'published',
         id: 'published',
@@ -563,9 +596,15 @@ function DashboardList(props: DashboardListProps) {
           { label: t('Published'), value: true },
           { label: t('Draft'), value: false },
         ],
-      },
-      ...(userId ? [favoritesFilter] : []),
-      {
+      });
+    }
+
+    if (canSeeFavoriteFilter) {
+      filters_list.push(...(userId ? [favoritesFilter] : []));
+    }
+
+    if (canSeeCertifiedFilter) {
+      filters_list.push({
         Header: t('Certified'),
         key: 'certified',
         id: 'id',
@@ -577,8 +616,9 @@ function DashboardList(props: DashboardListProps) {
           { label: t('Yes'), value: true },
           { label: t('No'), value: false },
         ],
-      },
-    ] as Filters;
+      });
+    }
+
     if (isFeatureEnabled(FeatureFlag.TAGGING_SYSTEM)) {
       filters_list.push({
         Header: t('Tags'),

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -259,6 +259,14 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         ("can_read", "Database"),
     }
 
+    DASHBOARD_LIST_FILTER_PERMISSIONS ={
+        ("can_show_owner_filter", "Dashboard"),
+        ("can_show_created_by_filter", "Dashboard"),
+        ("can_show_published_filter", "Dashboard"),
+        ("can_show_favorite_filter", "Dashboard"),
+        ("can_show_certified_filter", "Dashboard"),
+    }
+
     data_access_permissions = (
         "database_access",
         "schema_access",
@@ -728,6 +736,11 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         self.add_permission_view_menu("can_csv", "Superset")
         self.add_permission_view_menu("can_share_dashboard", "Superset")
         self.add_permission_view_menu("can_share_chart", "Superset")
+        self.add_permission_view_menu("can_show_owner_filter", "Dashboard")
+        self.add_permission_view_menu("can_show_created_by_filter", "Dashboard")
+        self.add_permission_view_menu("can_show_published_filter", "Dashboard")
+        self.add_permission_view_menu("can_show_favorite_filter", "Dashboard")
+        self.add_permission_view_menu("can_show_certified_filter", "Dashboard")
 
     def create_missing_perms(self) -> None:
         """


### PR DESCRIPTION
…st view (for Owner, Certified by,

Status, Published and Certified dropdowns)
	modified:   superset-frontend/src/pages/DashboardList/index.tsx
	modified:   superset/security/manager.py

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
created permissions to control the visibility of the `/dashboard/list` header filters

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
