### PR TITLE
SN-516/feat/Extending existing permissions for dashboard list columns

### DIFF
--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -179,30 +179,30 @@ function DashboardList(props: DashboardListProps) {
   const canExport =
     hasPerm('can_export') && isFeatureEnabled(FeatureFlag.VERSIONED_EXPORT);
   const canSeeOwnerFilter = userHasPermission(
-      props.user,
-      'Dashboard',
-      'can_show_owner_filter',
-    );
-    const canSeeCreatedByFilter = userHasPermission(
-      props.user,
-      'Dashboard',
-      'can_show_created_by_filter',
-    );
-    const canSeeFavoriteFilter = userHasPermission(
-      props.user,
-      'Dashboard',
-      'can_show_favorite_filter',
-    );
-    const canSeePublishedFilter = userHasPermission(
-      props.user,
-      'Dashboard',
-      'can_show_published_filter',
-    );
-    const canSeeCertifiedFilter = userHasPermission(
-      props.user,
-      'Dashboard',
-      'can_see_certified_filter',
-    );
+    props.user,
+    'Dashboard',
+    'can_show_owner_filter',
+  );
+  const canSeeCreatedByFilter = userHasPermission(
+    props.user,
+    'Dashboard',
+    'can_show_created_by_filter',
+  );
+  const canSeeFavoriteFilter = userHasPermission(
+    props.user,
+    'Dashboard',
+    'can_show_favorite_filter',
+  );
+  const canSeePublishedFilter = userHasPermission(
+    props.user,
+    'Dashboard',
+    'can_show_published_filter',
+  );
+  const canSeeCertifiedFilter = userHasPermission(
+    props.user,
+    'Dashboard',
+    'can_see_certified_filter',
+  );
 
   const initialSort = [{ id: 'changed_on_delta_humanized', desc: true }];
 
@@ -337,7 +337,7 @@ function DashboardList(props: DashboardListProps) {
           row: {
             original: { changed_by_name: changedByName },
           },
-        }: any) =><>{changedByName}</>,
+        }: any) => <>{changedByName}</>,
         Header: t('Modified by'),
         accessor: 'changed_by.first_name',
         size: 'xl',


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Reused permissions from SN-315 to control visibility of columns from dashboard list view.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
